### PR TITLE
Don't fail on empty staple files

### DIFF
--- a/ocspd/core/certmodel.py
+++ b/ocspd/core/certmodel.py
@@ -112,7 +112,10 @@ class CertModel(object):
             LOG.error("Can't access %s, let's schedule a renewal.", ocsp_file)
             return False
 
-        # from haproxy docs: [...] The content of this file is optional [...]
+        # For some reason there are reports that haproxy will not accept staples
+        # from with the `set ssl ocsp-response [data]` command if a staple file
+        # did not already exist at start-up, an empty file seems to fix that.
+        # https://www.mail-archive.com/haproxy@formilux.org/msg24750.html
         if len(staple) == 0:
             LOG.info("Staple %s is empty, schedule a renewal.", ocsp_file)
             return False

--- a/ocspd/core/certmodel.py
+++ b/ocspd/core/certmodel.py
@@ -112,6 +112,11 @@ class CertModel(object):
             LOG.error("Can't access %s, let's schedule a renewal.", ocsp_file)
             return False
 
+        # from haproxy docs: [...] The content of this file is optional [...]
+        if len(staple) == 0:
+            LOG.info("Staple %s is empty, schedule a renewal.", ocsp_file)
+            return False
+
         staple = OCSPResponseParser(staple)
         now = datetime.datetime.now()
         until = staple.valid_until


### PR DESCRIPTION
HAProxy intentionally allows empty stable files and treat them as non-existent. In fact creating an empty stable allows to set the stable at runtime which isn't possible if it's omitted beforehand. Parsing an empty file won't work, so handle it as non existent as well.